### PR TITLE
Updated Autofac dependency to 3.0.2

### DIFF
--- a/src/Nancy.Bootstrappers.Autofac.Tests/Nancy.Bootstrappers.Autofac.Tests.csproj
+++ b/src/Nancy.Bootstrappers.Autofac.Tests/Nancy.Bootstrappers.Autofac.Tests.csproj
@@ -31,13 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+    <Reference Include="Autofac, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.dll</HintPath>
+      <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+    <Reference Include="Autofac.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.Configuration.dll</HintPath>
+      <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Nancy.Bootstrappers.Autofac.Tests/packages.config
+++ b/src/Nancy.Bootstrappers.Autofac.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="2.6.3.862" />
+  <package id="Autofac" version="3.0.2" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
 </packages>

--- a/src/Nancy.Bootstrappers.Autofac/Nancy.Bootstrappers.Autofac.csproj
+++ b/src/Nancy.Bootstrappers.Autofac/Nancy.Bootstrappers.Autofac.csproj
@@ -31,13 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+    <Reference Include="Autofac, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.dll</HintPath>
+      <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Autofac.Configuration, Version=2.6.3.862, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+    <Reference Include="Autofac.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.Configuration.dll</HintPath>
+      <HintPath>..\packages\Autofac.3.0.2\lib\net40\Autofac.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Nancy.Bootstrappers.Autofac/packages.config
+++ b/src/Nancy.Bootstrappers.Autofac/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="2.6.3.862" />
+  <package id="Autofac" version="3.0.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I have updated Autofac to the 3.0 package. The version number used in the package.config is 3.0.2 but the actual assembly version referenced by the project is 3.0.0.0. This is because the assembly version has been locked at 3.0.0.0, while the file and package versions for Autofac are incremented to avoid strong naming issues.
