### PR TITLE
Bugfix, autofac prioritizes last registration.

### DIFF
--- a/src/Nancy.Bootstrappers.Autofac/AutofacNancyBootstrapper.cs
+++ b/src/Nancy.Bootstrappers.Autofac/AutofacNancyBootstrapper.cs
@@ -92,7 +92,7 @@ namespace Nancy.Bootstrappers.Autofac
             {
                 foreach (var implementationType in collectionTypeRegistration.ImplementationTypes)
                 {
-                    builder.RegisterType(implementationType).As(collectionTypeRegistration.RegistrationType).SingleInstance();
+                    builder.RegisterType(implementationType).As(collectionTypeRegistration.RegistrationType).PreserveExistingDefaults().SingleInstance();
                 }
             }
             builder.Update(container.ComponentRegistry);


### PR DESCRIPTION
Nancy sends a list of where the higest prioritized item is first. This means that ISerializer overrides will not hit since DefaultJsonSerializer will be first in the list.
